### PR TITLE
Fix/reset values on fields

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "datocms-plugin-chat-gpt",
-  "version": "0.1.0",
+  "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "datocms-plugin-chat-gpt",
-      "version": "0.1.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "@testing-library/jest-dom": "^5.16.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datocms-plugin-chat-gpt-ai-content-generator",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "AI assistant to quickly generate realistic content based on keywords using ChatGPT v3 (OpenAI).",
   "private": false,
   "scripts": {

--- a/src/entrypoints/FieldExtension.tsx
+++ b/src/entrypoints/FieldExtension.tsx
@@ -30,10 +30,10 @@ export default function FieldExtension({ ctx }: Props) {
   const [usage, setUsage] = useState(usageProps)
   const [isGenerated, setIsGenerated] = useState(false)
 
-  const fieldId = ctx.field.id
+  const fieldId = `${ctx.item?.id}-${ctx.field.id}`
   const pluginParams = ctx.plugin.attributes.parameters as ConfigParameters
   const initialValue =
-    pluginParams.fields && pluginParams.fields[fieldId as never]
+    pluginParams.fields && pluginParams.fields[fieldId as never] && ctx.item?.id
       ? pluginParams.fields[fieldId as never]
       : {}
 
@@ -57,10 +57,12 @@ export default function FieldExtension({ ctx }: Props) {
         onSubmit={async (values: FieldConfigParameters) => {
           const fields = { ...pluginParams.fields, [fieldId]: values }
 
-          await ctx.updatePluginParameters({
-            ...pluginParams,
-            fields,
-          })
+          if (ctx.item?.id) {
+            await ctx.updatePluginParameters({
+              ...pluginParams,
+              fields,
+            })
+          }
 
           setIsLoading(true)
           setUsage(usageProps)


### PR DESCRIPTION
This pull request fixes the overriding plugin fields when generating new texts with keywords and the [issue-1](https://github.com/voorhoede/datocms-plugin-chat-gpt/issues/1) described by @lsarni. If the item id is available we now combine those item and field id's to have a unique key to save previous plugin preferences in the current content model. 